### PR TITLE
Update func.md

### DIFF
--- a/docs/semantics/func.md
+++ b/docs/semantics/func.md
@@ -9,37 +9,28 @@ The `func` type will reference a function in FIRE. The `func` type can be passed
 #### Declaration
 
 the `func` type is declared in the following format\:
-`func <name> = (<parameters>) => { <function body> };`
+`func <return type> <name> = (<parameters>) => { <function body> };`
 
-where:  
- * `<name>` is the variable name of the func.  
- * `<paramters>` are the expected parameters for the function.  
- * `<function body>` is the body of the function.
+where:
+ * `<return type>` is the type returned by the function
+ * `<name>` is the variable name of the function
+ * `<paramters>` are the expected parameters for the function
+ * `<function body>` is the body of the function
  
 Once a function has been assigined to a `func` type it becomes a "named function" that is callable using that name e.g `funcName();`
 
-#### Anonymous Functions
-
-Annoynomous functions are functions that have not been assigned to a `func` variable. They are entirely interchangabe with named functions every where a func is expected, but can not be called unless assigned to a func type. This happens implicitly when passed as a parameter.
-
-`(<parameters>) => {<function body>}`
-
 #### Paramaterization
 
-Both named and annonymous functions can be passed to other functions as a parameter as follows\:
+Both named functions can be passed to other functions as a parameter as follows\:
 
 ```
 // named
-func saySomething () =>{ print("something"); };
-func doSomething = (func f) => { f(); };
+func void saySomething = () =>{ print("something"); };
+func void doSomething = (func f) => { f(); };
 doSomething(saySomething);
-
-//anonymous
-doSomething( () => { print("something"); } );
 ```
 
 ## Semantics
 
 * Fire does not support function overloading
 * Fire does not support genericity in functions
-


### PR DESCRIPTION
After working on the `parser` and realizing we need to have a return type, anonymous functions don't really fit into the language. We have functions as type, so we're able to pass them around. This provides the same functionality as anonymous functions but without the complicated representation. 