### PR TITLE
Adds basic code generation

### DIFF
--- a/src/codegen.ml
+++ b/src/codegen.ml
@@ -1,0 +1,50 @@
+(* Code generation: translate takes a semantically checked AST and
+produces LLVM IR
+
+LLVM tutorial: Make sure to read the OCaml version of the tutorial
+
+http://llvm.org/docs/tutorial/index.html
+
+Detailed documentation on the OCaml LLVM library:
+
+http://llvm.moe/
+http://llvm.moe/ocaml/
+
+*)
+
+(* We'll refer to Llvm and Ast constructs with module names *)
+module L = Llvm
+module A = Ast
+(* open Sast *)
+
+module StringMap = Map.Make(String)
+
+(* Code Generation from the SAST. Returns an LLVM module if successful,
+   throws an exception if something is wrong. *)
+let translate (globals, functions) =
+  let context    = L.global_context () in
+
+  (* Add types to the context so we can use them in our LLVM code *)
+  let i32_t      = L.i32_type    context
+  and i8_t       = L.i8_type     context
+  and i1_t       = L.i1_type     context
+  and void_t     = L.void_type   context
+  (* Create an LLVM module -- this is a "container" into which we'll
+     generate actual code *)
+  and the_module = L.create_module context "Fire" in
+
+  (* Convert Fire types to LLVM types *)
+  let ltype_of_typ = function
+      A.Int   -> i32_t
+    | A.Bool  -> i1_t
+    | A.Void  -> void_t
+  in
+
+  (* Declare each global variable; remember its value in a map *)
+  let global_vars : L.llvalue StringMap.t =
+    let global_var m (typ, n, _) =
+      let init = match typ with
+        | _ -> L.const_int (ltype_of_typ typ) 0
+      in StringMap.add n (L.define_global n init the_module) m in
+    List.fold_left global_var StringMap.empty globals in  the_module
+

--- a/src/fire.ml
+++ b/src/fire.ml
@@ -1,19 +1,27 @@
 (* Top-level of the Fire compiler: scan & parse the input,
    check the resulting AST, generate LLVM IR, and dump the module *)
 
-type action = Ast (*| Compile*)
+(*     ("-s", Arg.Unit (set_action Sast), "Print the SAST"); *)
+
+type action = Ast | Sast | LLVM_IR | Compile
 
 let _ =
-  let lexbuf = Lexing.from_channel stdin in
-  let ast = Parser.program Scanner.token lexbuf in print_string (Ast.string_of_program ast)
+  let action = ref Compile in
+  let set_action a () = action := a in
+  let speclist = [
+    ("-a", Arg.Unit (set_action Ast), "Print the AST");
+    ("-l", Arg.Unit (set_action LLVM_IR), "Print the generated LLVM IR");
+    ("-c", Arg.Unit (set_action Compile),
+      "Check and print the generated LLVM IR (default)");
+  ] in
+  let usage_msg = "usage: ./fire.native [-a|-s|-l|-c] [file.fire]" in
+  let channel = ref stdin in
+  Arg.parse speclist (fun filename -> channel := open_in filename) usage_msg;
 
-(*
-  let action = if Array.length Sys.argv > 1 then
-          List.assoc Sys.argv.(1) [ ("-a", Ast);]	(* Print the AST only *)
-			      ("-c", Compile) ] (* Generate, check LLVM IR *)
-  else Ast in
-  match action with
-            Ast -> print_string (Ast.string_of_program ast)
-          | Compile -> let m = Codegen.translate ast in
-    Llvm_analysis.assert_valid_module m;
-    print_string (Llvm.string_of_llmodule m)*)
+  let lexbuf = Lexing.from_channel stdin in
+
+  let ast = Parser.program Scanner.token lexbuf in
+  match !action with
+    Ast -> print_string (Ast.string_of_program ast)
+    | LLVM_IR -> print_string (Llvm.string_of_llmodule (Codegen.translate ast))
+


### PR DESCRIPTION
This PR Adds very basic code generation. Just getting the skeleton up and working so we can add more features to it. Currently it parses global variables of type `int` and initializes them to `0`.

Example:
```
root@9fa19f9d5406:/home/fire# ./fire.native -a
int x; int y; int z;
int z;
int y;
int x;

root@9fa19f9d5406:/home/fire# ./fire.native -l
int x; int y; int z;
; ModuleID = 'Fire'
source_filename = "Fire"

@z = global i32 0
@y = global i32 0
@x = global i32 0
```