### PR TITLE
Adds batteries package to Dockerfile and linking in Makfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,8 @@ RUN ln -s /usr/bin/llc-6.0 /usr/bin/llc
 RUN opam init
 RUN opam install \
     llvm.6.0.0 \
-    ocamlfind
+    ocamlfind  \
+	batteries
 
 WORKDIR /root
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -7,7 +7,7 @@
 all : fire.native arrlib.o
 
 fire.native :
-	ocamlbuild -use-ocamlfind -pkgs llvm,llvm.analysis -cflags -w,+a-4 \
+	ocamlbuild -use-ocamlfind -pkgs llvm,llvm.analysis,batteries -cflags -w,+a-4 \
 		fire.native
 
 # "make clean" removes all generated files


### PR DESCRIPTION
Because we're using the `expr option` type, we can deal with a lot of the `None Some` nonsense with this package.

http://ocaml-lib.sourceforge.net/doc/Option.html