### PR TITLE
Adds support for matching on regular expressions and strings

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -4,7 +4,7 @@
 
 # Easiest way to build: using ocamlbuild, which in turn uses ocamlfind
 
-all : fire.native arrlib.o printlib.o
+all : fire.native arrlib.o printlib.o regexlib.o
 
 fire.native :
 	ocamlbuild -use-ocamlfind -pkgs llvm,llvm.analysis,batteries -cflags -w,+a-4 \
@@ -40,6 +40,9 @@ parser.ml parser.mli : parser.mly
 
 %.cmx : %.ml
 	ocamlfind ocamlopt -c -package llvm $<
+
+regexlib: regexlib.c
+	cc -o regexlib -DBUILD_TEST regexlib.c
 
 printlib: printlib.c
 	cc -o printlib -DBUILD_TEST printlib.c

--- a/src/arrlib.c
+++ b/src/arrlib.c
@@ -1,3 +1,0 @@
-int main() {
-	return 0;
-}

--- a/src/ast.ml
+++ b/src/ast.ml
@@ -20,14 +20,15 @@ type expr =
   | Unop of uop * expr
   | Retrieve of string * expr
   | Call of string * expr list
+  | RegexComp of expr * expr
   | Noexpr
 
-type bind = typ * string * expr 
+type bind = typ * string * expr
 
 type stmt =
     Block of stmt list
   | Expr of expr
-  | Return of expr 
+  | Return of expr
   | If of expr * stmt * stmt
   | While of expr * stmt
   | For of typ * string * string * stmt

--- a/src/parser.mly
+++ b/src/parser.mly
@@ -115,9 +115,9 @@ expr:
   | expr LTEQ   expr { Binop($1, Lteq,   $3) }
   | expr GT     expr { Binop($1, Gt, $3) }
   | expr GTEQ   expr { Binop($1, Gteq,   $3) }
-  | expr REQ    expr { Binop($1, Req,   $3) }
   | expr AND    expr { Binop($1, And,   $3) }
   | expr OR     expr { Binop($1, Or,    $3) }
+  | expr REQ    expr { RegexComp($1, $3) }
   | MINUS expr %prec NEG { Unop(Neg, $2) }
   | NOT expr         { Unop(Not, $2) }
   | ID LPAREN actuals_opt RPAREN { Call($1, $3) }

--- a/src/regexlib.c
+++ b/src/regexlib.c
@@ -1,0 +1,53 @@
+#include <stdio.h>
+#include <regex.h>
+#include <string.h>
+#include <sys/types.h>
+
+/*
+ * Simple wrapper for the regex GNU C interface
+ *
+ * returns 1 on match, otherwise 0
+ */
+int regex_compare(char *regex, char *operand) {
+	char clean_regex[strlen(regex)-2];
+	char clean_operand[strlen(operand)-2];
+	int i;
+	regex_t preg;
+
+#ifdef DEBUG
+	printf("{%s}\n", regex);
+	printf("{%s}\n", operand);
+#endif
+
+	for(i=1; i < strlen(regex)-1; i++) { clean_regex[i-1] = regex[i]; }
+	clean_regex[i-1] = '\0';
+	for(i=1; i < strlen(operand)-1; i++) { clean_operand[i-1] = operand[i]; }
+	clean_operand[i-1] = '\0';
+
+#ifdef DEBUG
+	printf("{%s}\n", clean_regex);
+	printf("{%s}\n", clean_operand);
+#endif
+
+	if(regcomp(&preg, (const char *)clean_regex, 0) != 0) {
+		printf("regcomp() failed");
+	}
+
+	int ret = regexec((const regex_t *)&preg, clean_operand, 0, 0, 0);
+
+#ifdef DEBUG
+	if(ret == 0) {
+		printf("library says there is a match\n");
+	} else {
+		printf("library says there is NOT a match\n");
+	}
+#endif
+	if(ret == 0) return 1;
+	return 0;
+}
+
+#ifdef BUILD_TEST
+int main() {
+	regex_compare("\"[:alpha:]\"", "4115hello4115");
+}
+#endif


### PR DESCRIPTION
Test program:

```
root@5993219c50fd:/home/fire# cat req.fire
func void check = (regx reg, str target) => {
	sprint("");

	sprint(reg);
	sprint(target);

	if(reg === target) {
		sprint("matches");
	} else {
		sprint("does not match");
	}
	sprint("");
}

func int main = () => {
	check("[:alpha:]", "12345");
	check("[:alpha:]", "");
	check("a.c", "azc");
	check("ac", "azc");
	check("c$", "this should match against .... c");
	return 0;
}
root@5993219c50fd:/home/fire#
```