### PR TITLE
Adds top level Makefile for automatic testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+all: clean source tests
+
+source:
+	$(MAKE) -C src/ all
+
+tests:
+	./testall.sh
+
+.ONESHELL:
+clean:
+	./testall.sh -c
+	$(MAKE) -C src/ clean

--- a/testall.sh
+++ b/testall.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Testing script for FIRE
-# 
+#
 #  Compile, run, and check the output of each test against expected result
 #  Expected failures run diff against the expected error, expected passes check against the expected output of the file
 
@@ -75,8 +75,8 @@ RunFail() {
 }
 
 Clean() {
-    rm test-*
-    rm fail-*
+    rm -f test-*
+    rm -f fail-*
     echo "cleaning all diff and err files from root"
     exit 1
 }


### PR DESCRIPTION
At the top directory, run `make all` which will run the Makefile in the
`src/`, then run the `testall.sh` script.